### PR TITLE
fix build failed

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -38,7 +38,7 @@ module.exports = {
       `,
         resolveSiteUrl: () => siteUrl,
         exclude: ["/en-US", "/en-US/**", "/termsOfUse", "/privacyPolicy"],
-        serialize: ({ query: { allSitePage, allWordpressPost } }) => {
+        serialize: ({ allSitePage, allWordpressPost }) => {
           const pages = allSitePage.nodes.map(node => ({
             url: `${siteUrl}${node.path}`,
             changefreq: node.path === "/" ? "daily" : "weekly",


### PR DESCRIPTION
Fix two issues:                                
  1. The serialize function — the plugin passes the filtered data directly (no query wrapper), causing Cannot read property 'allSitePage' of undefined
  2. gatsby-browser.js using onRenderBody — that's an SSR-only API; it was already there but I shouldn't have left it in my WebMCP addition (though it's a    
  warning, not the build failure)   